### PR TITLE
Update L1 URL as l1.testnet.nahmii.io is not working at the moment

### DIFF
--- a/niifi-v1-core/.env
+++ b/niifi-v1-core/.env
@@ -2,6 +2,6 @@
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 PRIVATE_KEY_OTHER=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 #FACTORY_ADDRESS=<some factory address to be reused>
-L1_URL=https://l1.testnet.nahmii.io
+L1_URL=https://ropsten.infura.io/v3/04d5eabe96774ce6846328fd7ef49c6f
 L2_URL=https://l2.testnet.nahmii.io
 L2_CHAIN_ID=5553


### PR DESCRIPTION
stuck at "waiting for blocks" as l1.testnet.nahmii.io is not working at the moment.
test:nvm is still slow and might have to increase timeout time in .mocharc.json