### PR TITLE
Get the types of HttpNetworkConfig gas and gasPrice properties right

### DIFF
--- a/niifi-v1-core/hardhat.config.js
+++ b/niifi-v1-core/hardhat.config.js
@@ -37,8 +37,8 @@ module.exports = {
         nahmii: {
             url: process.env.L2_URL,
             accounts,
-            gasPrice: ( process.env.GAS_PRICE || 15000000 ),
-            gas: ( process.env.GAS || 27000000 ),
+            gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : "auto",
+            gas: process.env.GAS ? parseInt(process.env.GAS) : "auto",
         }
     },
 };

--- a/niifi-v1-periphery/hardhat.config.js
+++ b/niifi-v1-periphery/hardhat.config.js
@@ -37,8 +37,8 @@ module.exports = {
         nahmii: {
             url: process.env.L2_URL,
             accounts,
-            gasPrice: ( process.env.GAS_PRICE || 15000000 ),
-            gas: ( process.env.GAS || 9000000 ),
+            gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : "auto",
+            gas: process.env.GAS ? parseInt(process.env.GAS) : "auto",
         }
     }
 };


### PR DESCRIPTION
This PR assures that the types of `HttpNetworkConfig`'s `gas` and `gasPrice` properties are correct in the event of providing environment variables for numerical values.